### PR TITLE
Build on ARM both in and out of rack

### DIFF
--- a/src/sapphire_engine.hpp
+++ b/src/sapphire_engine.hpp
@@ -6,7 +6,18 @@
 #include <algorithm>
 #include <vector>
 #include <stdexcept>
+
+/*
+ * In the rack context this ifdef isn't needed; rack gives you simde for free
+ * but if you want to use this module outside of rack (which we do) you need to
+ * have a bring-your-own simde approach which will just use RACK SIMDE in rack builds
+ */
+#if defined(__SSE2__)
 #include <pmmintrin.h>
+#else
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include "simde/x86/sse4.2.h"
+#endif
 
 namespace Sapphire
 {


### PR DESCRIPTION
This diff allows sapphire_engine.hpp to include simde properly which means it will compile ARM on rack, but also compile ARM in non-rack environments which bring simde along. (If this was rack only you could just use rack.hpp of course).