### PR TITLE
Improve the Rack/NoRack ifdef

### DIFF
--- a/src/sapphire_engine.hpp
+++ b/src/sapphire_engine.hpp
@@ -7,16 +7,21 @@
 #include <vector>
 #include <stdexcept>
 
+#ifdef NO_RACK_DEPENDENCY
 /*
  * In the rack context this ifdef isn't needed; rack gives you simde for free
  * but if you want to use this module outside of rack (which we do) you need to
  * have a bring-your-own simde approach which will just use RACK SIMDE in rack builds
  */
-#if defined(__SSE2__)
-#include <pmmintrin.h>
-#else
+#if defined(__arm64)
 #define SIMDE_ENABLE_NATIVE_ALIASES
 #include "simde/x86/sse4.2.h"
+#else
+#include <pmmintrin.h>
+#endif
+
+#else
+#include "rack.hpp"
 #endif
 
 namespace Sapphire


### PR DESCRIPTION
1. Make the AVOID_RACK explicit
2. If in AVOID_RACK mode, use __arm as a positive assert not __SSE2__

If you merge this I can update the plugin also to have a more uniform build.

Thanks!